### PR TITLE
Dev/product add item fields

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ junk/*
 output/*
 url_file.txt
 .vscode/*
+.scrapy/*

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 *.pyc
 junk/*
+output/*
+url_file.txt

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 junk/*
 output/*
 url_file.txt
+.vscode/*

--- a/steam/items.py
+++ b/steam/items.py
@@ -75,8 +75,12 @@ class ProductItem(scrapy.Item):
     genres = scrapy.Field(
         output_processor=Compose(TakeFirst(), lambda x: x.split(','), MapCompose(StripText()))
     )
-    developer = scrapy.Field()
-    publisher = scrapy.Field()
+    developer = scrapy.Field(
+        output_processor=MapCompose(StripText())
+    )
+    publisher = scrapy.Field(
+        output_processor=MapCompose(StripText())
+    )
     release_date = scrapy.Field(
         output_processor=Compose(TakeFirst(), StripText(), standardize_date)
     )

--- a/steam/items.py
+++ b/steam/items.py
@@ -3,7 +3,7 @@ import logging
 
 import scrapy
 from scrapy.loader import ItemLoader
-from scrapy.loader.processors import Compose, Join, MapCompose, TakeFirst
+from itemloaders.processors import Compose, Join, MapCompose, TakeFirst
 
 logger = logging.getLogger(__name__)
 
@@ -107,6 +107,10 @@ class ProductItem(scrapy.Item):
         output_processor=Compose(TakeFirst(), StripText(), str_to_int)
     )
     early_access = scrapy.Field()
+    short_description = scrapy.Field()
+    long_description = scrapy.Field()
+    cover_image_url = scrapy.Field()
+    game_image_url = scrapy.Field()
 
 
 class ReviewItem(scrapy.Item):

--- a/steam/items.py
+++ b/steam/items.py
@@ -111,8 +111,15 @@ class ProductItem(scrapy.Item):
         output_processor=Compose(TakeFirst(), StripText(), str_to_int)
     )
     early_access = scrapy.Field()
-    short_description = scrapy.Field()
-    long_description = scrapy.Field()
+
+    short_description = scrapy.Field(
+        output_processor=Compose(TakeFirst(), StripText())
+    )
+
+    long_description = scrapy.Field(
+        output_processor=Compose(TakeFirst(), StripText())
+    )
+
     cover_image_url = scrapy.Field()
     game_image_url = scrapy.Field()
 

--- a/steam/spiders/product_spider.py
+++ b/steam/spiders/product_spider.py
@@ -12,6 +12,7 @@ logger = logging.getLogger(__name__)
 
 
 def load_product(response):
+    #TODO: fix developer, publisher, release date; add short description, long description
     """Load a ProductItem from the product page response."""
     loader = ProductItemLoader(item=ProductItem(), response=response)
 

--- a/steam/spiders/product_spider.py
+++ b/steam/spiders/product_spider.py
@@ -50,8 +50,6 @@ def load_product(response):
     loader.add_value('publisher', publisher)
     loader.add_css('release_date', '.release_date .date ::text')
 
-    #TODO: add short description, long description
-
     loader.add_css('app_name', '.apphub_AppName ::text')
     loader.add_css('specs', '.game_area_details_specs a ::text')
     loader.add_css('tags', 'a.app_tag::text')
@@ -76,6 +74,20 @@ def load_product(response):
         loader.add_value('early_access', True)
     else:
         loader.add_value('early_access', False)
+
+    #short_description = re.sub('[\r\t\n]', '', response.css('.game_description_snippet ::text').extract()).strip()
+    short_description = response.css('.game_description_snippet ::text').extract()
+    loader.add_value('short_description', short_description)
+
+    #long_description = re.sub('[\t]', '', response.css('.game_area_description#game_area_description').extract()).strip()
+    long_description = response.css('.game_area_description#game_area_description').extract()
+    loader.add_value('long_description', long_description)
+
+    loader.add_xpath('cover_image_url', '//img[@class="game_header_image_full"]/@src')
+
+    game_image_url = re.sub('\.[\d]*x[\d]*\.jpg.*', '.jpg', 
+        response.xpath('//div[@id="highlight_strip"]//img[not(contains(@class,"movie_thumb"))]/@src').extract_first())
+    loader.add_value('game_image_url', game_image_url)
 
     return loader.load_item()
 


### PR DESCRIPTION
Significant enhancements to product crawler:
-Fixed developer, publisher, release date fields fetch
-Added short_description, long_description, cover_image_url and game_image_url fields

Minor enhancements:
-Resolved deprecation warnings for scrapy import
-Gitignore extended to ignore various relevant temporary files